### PR TITLE
Fix mobile nav bug

### DIFF
--- a/CooperationHullMainSite/wwwroot/css/site.css
+++ b/CooperationHullMainSite/wwwroot/css/site.css
@@ -106,7 +106,6 @@ h1 {
 }
 
 .navbar-toggler:focus {
-    border: 0px;
     box-shadow: none;
     border: none;
 }
@@ -166,7 +165,7 @@ h1 {
     display: none;
 }
 
-@media (max-width: 1024px) {
+@media (max-width: 991px) {
     .mobile-only {
         display: block;
     }
@@ -195,7 +194,7 @@ h1 {
         align-items: center;
         padding: 30px;
         position: fixed;
-        top: 0px;
+        top: 0;
         right: 0;
         height: 100%;
         background-color: var(--off-white-solid);


### PR DESCRIPTION
Quick fix for the mobile anv bug (https://github.com/Fireflower2012/CooperationHullMainSite/issues/84).

The issue was that we were using `1024px` for the breakpoint, but bootstrap uses `922px` implicitly within the `navbar-expand-lg` class that does the expanding for us. I had to update mobile nav breakpoint to `911px` manually (since we are using `max-width` here so need to subtract 1 to handle the exclusive range).

Maybe there's a better way to match bootstraps breakpoints, and we could make this a bit more intuitive by using a mobile-first approach, but getting this quick fix out for now!