### PR TITLE
Make happening next items take up full height

### DIFF
--- a/CooperationHullMainSite/wwwroot/css/site.css
+++ b/CooperationHullMainSite/wwwroot/css/site.css
@@ -709,6 +709,9 @@ section:has(+ .call-out-block-wrapper) {
 .happening-next-item {
     position: relative;
     width: 100%;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
     background-color: var(--off-black);
     color: var(--cooperation-white);
     border-radius: 8px;
@@ -740,6 +743,8 @@ section:has(+ .call-out-block-wrapper) {
     padding: 1.5rem;
     display: flex;
     flex-direction: column;
+    justify-content: space-between;
+    flex-grow: 1;
     gap: 1rem;
 }
 


### PR DESCRIPTION
As discussed in weekly. Description lengths still shouldn't vary _too_ much, as there will be some empty space.