### PR TITLE
Changed youtube link to cookie free version

### DIFF
--- a/CooperationHullMainSite/Views/Home/Index.cshtml
+++ b/CooperationHullMainSite/Views/Home/Index.cshtml
@@ -132,7 +132,7 @@
 
 <section class="homepage-block hww">
         <div class="video">
-            <iframe src="https://www.youtube.com/embed/O7iHDDg2skU?si=RBYJHIqmoN_PR37h" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+            <iframe src="https://www.youtube-nocookie.com/embed/O7iHDDg2skU?si=RBYJHIqmoN_PR37h" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
         </div>
         <div class="blurb">
             <h1>How We Work</h1>


### PR DESCRIPTION
Quick PR to change the embeded youtube video to the no cookie version to make policy writing a whole lot easier