### PR TITLE
Improve padding consistency

### DIFF
--- a/CooperationHullMainSite/Views/Home/Index.cshtml
+++ b/CooperationHullMainSite/Views/Home/Index.cshtml
@@ -131,10 +131,11 @@
 
 
 <section class="homepage-block hww">
-        <div class="video">
+    <div class="row align-items-center">
+        <div class="col-lg-6 col-md-12 p-4 video">
             <iframe src="https://www.youtube.com/embed/O7iHDDg2skU?si=RBYJHIqmoN_PR37h" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
         </div>
-        <div class="blurb">
+        <div class="col-lg-6 col-md-12 p-4 blurb">
             <h1>How We Work</h1>
             <p>We start local, work with what we've got already (which in Hull, is a LOT), experiment all the time, and learn from each other. </p>
             <br/>
@@ -145,14 +146,13 @@
         <div class="spot">
             <img src="./assets/img/spot 1 1 2.png">
         </div>
-    
-
+    </div>
 </section>
 
 <section class="homepage-block orange">
     <div class="row">
         <div class="col-12">
-            <h2 class="heading-lg text-center py-4">What's happening next?</h2>
+            <h2 class="heading-lg text-center pt-3 pb-5">What's happening next?</h2>
 
             <div class="row gx-5 gy-4">
                 @foreach (HappenginNextEvent eventItem in Model.eventList)

--- a/CooperationHullMainSite/wwwroot/css/site.css
+++ b/CooperationHullMainSite/wwwroot/css/site.css
@@ -321,7 +321,12 @@ h1 {
 /* Homepage block */
 
 .homepage-block > .row {
-    padding: 4rem
+    padding: 3rem 2rem;
+}
+@media (min-width: 992px) {
+    .homepage-block > .row {
+        padding: 4rem;
+    }
 }
 
 .homepage-block > div {
@@ -403,7 +408,7 @@ h1 {
     display: flex;
     align-items: center;
     justify-content: center;
-    gap: 2%;
+    gap: 2rem;
     flex-wrap: wrap-reverse;
 
     background-color: #23201E;
@@ -412,16 +417,12 @@ h1 {
     overflow: hidden;
 
     color: white;
-    padding: 2% 12%;
-    padding-top: 200px;
+    padding: 2rem;
   }
 
   .hww::before {
     content: "";
     position: absolute;
-    width: 200%;
-    height: 200%;
-    
     width: 100%;
     height: 33%;
     bottom: 0;
@@ -440,11 +441,9 @@ h1 {
   }
 
     .hww .video {
-        width: 80%;
         z-index: 10;
         min-width: 50%;
         height: auto;
-        padding-top: calc(15% + 4rem);
     }
 
 .video > iframe {
@@ -457,7 +456,6 @@ h1 {
     height: 100%;
     padding-left: 10px;
     padding-right: 10px;
-    transform: translateY(4rem);
 }
 
   .blurb h1 {
@@ -502,7 +500,6 @@ h1 {
     }
 
         .hww .video {
-            width: 75%;
             min-width: 50%;
             height: auto;
             padding: 0% 0% 0 0;
@@ -594,22 +591,25 @@ h1 {
     max-width:100%;
 }
 
-    /* Safe zone within sibling sections that the call out block can "eat into". May need to be updated once responsivity is tweaked in other sections */
-    body {
-    --call-out-block-safe-area-y: 250px
+/* Safe zone within sibling sections that the call out block can "eat into". May need to be updated once responsivity is tweaked in other sections */
+body {
+    --call-out-block-safe-area-y: 260px
 }
 @media (min-width: 400px) {
     body {
-        --call-out-block-safe-area-y: 200px
+        --call-out-block-safe-area-y: 230px
     }
 }
 @media (min-width: 992px) {
     body {
-        --call-out-block-safe-area-y: 160px
+        --call-out-block-safe-area-y: 140px
     }
 }
 section:has(+ .call-out-block-wrapper) {
     padding-bottom: var(--call-out-block-safe-area-y);
+}
+.call-out-block-wrapper + section {
+    padding-top: calc(var(--call-out-block-safe-area-y));
 }
 
 .call-out-block-wrapper {


### PR DESCRIPTION
I noticed that there has been some room for improvement in the mobile section padding, as well as some recent regressions related to section spacing and other similar styles. I've tried to improve both in this PR, as well as ensure that we lay out sections consistently.

For the regressions, I think we're facing an issue with style clashes and unintentional changes thats related to us mixing paradigms when it comes to styling: some bootstrap, some direct CSS property edits, and some abstracted utility CSS that we've written. It makes it quite hard to judge the impact of one change! Though, potentially this is a situation we'll have to live with given we dont want to rearchitect all the styles.