### PR TITLE
Fix gap between how we work and what's happening next

### DIFF
--- a/CooperationHullMainSite/Views/Home/Index.cshtml
+++ b/CooperationHullMainSite/Views/Home/Index.cshtml
@@ -131,7 +131,7 @@
 
 
 <section class="homepage-block hww">
-    <div class="row align-items-center">
+    <div class="row align-items-center pb-0">
         <div class="col-lg-6 col-md-12 p-4 video">
             <iframe src="https://www.youtube-nocookie.com/embed/O7iHDDg2skU?si=RBYJHIqmoN_PR37h" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
         </div>

--- a/CooperationHullMainSite/wwwroot/css/site.css
+++ b/CooperationHullMainSite/wwwroot/css/site.css
@@ -486,10 +486,6 @@ h1 {
         
     }
 
-    .hww > .p-0 {
-        padding-bottom: 0;
-      }
-
     .hww::before {
         visibility: hidden;
     }

--- a/CooperationHullMainSite/wwwroot/css/site.css
+++ b/CooperationHullMainSite/wwwroot/css/site.css
@@ -434,10 +434,6 @@ h1 {
     background-repeat: no-repeat;
   }
 
-  .hww > .p-0 {
-    padding-bottom: 0;
-  }
-
   .hww .spot {
     position: absolute;
     right: 12%;
@@ -489,6 +485,10 @@ h1 {
         flex-wrap: nowrap;
         
     }
+
+    .hww > .p-0 {
+        padding-bottom: 0;
+      }
 
     .hww::before {
         visibility: hidden;

--- a/CooperationHullMainSite/wwwroot/css/site.css
+++ b/CooperationHullMainSite/wwwroot/css/site.css
@@ -418,6 +418,7 @@ h1 {
 
     color: white;
     padding: 2rem;
+    padding-bottom: 0;
   }
 
   .hww::before {
@@ -431,6 +432,10 @@ h1 {
 
     background-image: url("../assets/img/trees-pattern-grey.png");
     background-repeat: no-repeat;
+  }
+
+  .hww > .p-0 {
+    padding-bottom: 0;
   }
 
   .hww .spot {


### PR DESCRIPTION
I've added a `pb-0` rule onto the row element in "How We Work" so that the gap between the two sections is removed.